### PR TITLE
Easy svg usage with dot notation support.

### DIFF
--- a/config/form-components.php
+++ b/config/form-components.php
@@ -240,4 +240,33 @@ return [
     |
     */
     'asset_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Svg Icons (optional)
+    |
+    | Examples:
+    |
+    | Example icon directory tree:
+    | - resources
+    |   └── svg
+    |      └── icons
+    |         │─ outline
+    |         │  └── home.svg
+    |         └── home.svg
+    |
+    | 'svg_path' => 'svg/icons'
+    |
+    | <x-input leading-icon="home"
+    | <x-input leading-icon="outline.home"
+    |--------------------------------------------------------------------------
+    */
+    'svg_path' => null, // null = disable
+    'svg_attributes' => [
+        'xmlns'       => 'http://www.w3.org/2000/svg',
+        'viewBox'     => '0 0 20 20',
+        'fill'        => 'currentColor',
+        'aria-hidden' => 'true',
+        'class'       => 'h-6 w-6 text-gray'
+    ],
 ];

--- a/src/Components/Inputs/CustomSelect.php
+++ b/src/Components/Inputs/CustomSelect.php
@@ -63,6 +63,7 @@ class CustomSelect extends Select
         );
 
         $this->resolveIcons();
+        $this->resolveSvgIcons(false);
         $this->normalizeOptions($convertValuesToString);
         $this->placeholder = __($placeholder);
         $this->emptyText = __($emptyText);

--- a/src/Components/Inputs/DatePicker.php
+++ b/src/Components/Inputs/DatePicker.php
@@ -53,6 +53,7 @@ class DatePicker extends Input
         );
 
         $this->resolveIcons();
+        $this->resolveSvgIcons();
         $this->placeholder = __($placeholder);
     }
 

--- a/src/Components/Inputs/Input.php
+++ b/src/Components/Inputs/Input.php
@@ -54,6 +54,8 @@ class Input extends BladeComponent
         if (is_array($this->value)) {
             $this->value = json_encode($this->value);
         }
+
+        $this->resolveSvgIcons();
     }
 
     public function inputClass(): string

--- a/src/Components/Inputs/Password.php
+++ b/src/Components/Inputs/Password.php
@@ -42,6 +42,7 @@ class Password extends Input
 
         $this->showPasswordIcon = $this->showPasswordIcon ?? config('form-components.components.password.show_password_icon');
         $this->hidePasswordIcon = $this->hidePasswordIcon ?? config('form-components.components.password.hide_password_icon');
+        $this->resolveSvgIcons(false);
     }
 
     public function inputClass(): string

--- a/src/Components/Inputs/Select.php
+++ b/src/Components/Inputs/Select.php
@@ -46,6 +46,7 @@ class Select extends Input
             extraAttributes: $extraAttributes,
         );
 
+        $this->resolveSvgIcons();
         $this->selectedKey = old($this->name, $this->value);
     }
 

--- a/src/Components/Inputs/TimezoneSelect.php
+++ b/src/Components/Inputs/TimezoneSelect.php
@@ -49,6 +49,7 @@ class TimezoneSelect extends Select
             extraAttributes: $extraAttributes,
         );
 
+        $this->resolveSvgIcons();
         $this->only = is_null($only) ? config('form-components.timezone_subset', false) : $only;
         $this->placeholder = __($placeholder);
     }

--- a/src/Concerns/HasAddons.php
+++ b/src/Concerns/HasAddons.php
@@ -101,6 +101,7 @@ trait HasAddons
         if ($this->leadingIcon && ! Str::contains($this->leadingIcon, ['<', '>'])) {
             $this->leadingIcon = $this->setSvgHtml($this->leadingIcon);
         }
+        
         if ($hasTrailingIcon && $this->trailingIcon && ! Str::contains($this->trailingIcon, ['<', '>'])) {
             $this->trailingIcon = $this->setSvgHtml($this->trailingIcon);
         }

--- a/src/Concerns/HasAddons.php
+++ b/src/Concerns/HasAddons.php
@@ -2,6 +2,8 @@
 
 namespace Rawilk\FormComponents\Concerns;
 
+use Illuminate\Support\Str;
+
 trait HasAddons
 {
     public $leadingAddon;
@@ -68,6 +70,39 @@ trait HasAddons
             $this->trailingAddon = $data['trailingAddon'];
         } elseif ($data['trailingIcon'] !== false) {
             $this->trailingIcon = $data['trailingIcon'];
+        }
+    }
+
+    protected function setSvgHtml (false|string $path): false|string
+    {
+        $svgPath = config('form-components.svg_path');
+
+        if (is_null($svgPath)) {
+            return false;
+        }
+
+        $svgAttributes = config('form-components.svg_attributes', []);
+        try {
+            $path = 'fci-' . str_replace('/', '-', trim($path));
+            $svg = app(\BladeUI\Icons\Factory::class)->svg($path, '', $svgAttributes)->toHtml();
+        } catch (\BladeUI\Icons\Exceptions\SvgNotFound $e) {
+            $svg = false;
+        }
+
+        if (!is_null($svg)) {
+            return $svg;
+        }
+
+        return false;
+    }
+
+    protected function resolveSvgIcons(bool $hasTrailingIcon = true): void
+    {
+        if ($this->leadingIcon && ! Str::contains($this->leadingIcon, ['<', '>'])) {
+            $this->leadingIcon = $this->setSvgHtml($this->leadingIcon);
+        }
+        if ($hasTrailingIcon && $this->trailingIcon && ! Str::contains($this->trailingIcon, ['<', '>'])) {
+            $this->trailingIcon = $this->setSvgHtml($this->trailingIcon);
         }
     }
 }

--- a/src/FormComponentsServiceProvider.php
+++ b/src/FormComponentsServiceProvider.php
@@ -37,6 +37,7 @@ class FormComponentsServiceProvider extends ServiceProvider
         $this->registerFacade();
         $this->mergeConfigFrom(__DIR__ . '/../config/form-components.php', 'form-components');
         $this->registerTimezone();
+        $this->registerSvgIcons();
     }
 
     private function registerFacade(): void
@@ -120,6 +121,20 @@ class FormComponentsServiceProvider extends ServiceProvider
     {
         if (config('form-components.enable_timezone')) {
             $this->app->singleton('fc-timezone', fn () => new Timezone);
+        }
+    }
+
+    protected function registerSvgIcons (): void
+    {
+        $svgPath = config("form-components.svg_path");
+
+        if (!is_null($svgPath)) {
+            $this->callAfterResolving(\BladeUI\Icons\Factory::class, function (\BladeUI\Icons\Factory $factory) use ($svgPath) {
+                $factory->add('fcIcons', [
+                    'path'   => $this->app->resourcePath($svgPath),
+                    'prefix' => 'fci',
+                ]);
+            });
         }
     }
 }

--- a/src/FormComponentsServiceProvider.php
+++ b/src/FormComponentsServiceProvider.php
@@ -126,7 +126,7 @@ class FormComponentsServiceProvider extends ServiceProvider
 
     protected function registerSvgIcons (): void
     {
-        $svgPath = config("form-components.svg_path");
+        $svgPath = config('form-components.svg_path');
 
         if (!is_null($svgPath)) {
             $this->callAfterResolving(\BladeUI\Icons\Factory::class, function (\BladeUI\Icons\Factory $factory) use ($svgPath) {


### PR DESCRIPTION
```blade
<x-input leading-icon="hero.home" />
<x-input leading-icon="hero.outline.home" />

<x-input trailing-icon="hero.home" />
<x-input trailing-icon="hero.outline.home" />
```

Sorry, I didn't have time to write the tests.