### PR TITLE
Support for get the old value of a switch toggle without livewire

### DIFF
--- a/resources/views/components/choice/switch-toggle.blade.php
+++ b/resources/views/components/choice/switch-toggle.blade.php
@@ -87,6 +87,6 @@
     @endif
 
     @if ($name)
-        <input type="hidden" name="{{ $name }}" x-bind:value="JSON.stringify(value)" />
+        <input type="hidden" name="{{ $name }}" x-bind:value="value" />
     @endif
 </div>

--- a/src/Components/Choice/SwitchToggle.php
+++ b/src/Components/Choice/SwitchToggle.php
@@ -36,6 +36,7 @@ class SwitchToggle extends BladeComponent
     ) {
         $this->id = $this->id ?? $this->name;
         $this->labelId = $this->id ?? Str::random(8);
+        $this->value = $this->name ? old($this->name, $this->value) : $this->value;
     }
 
     public function labelId(): string


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

A problem was not created, but it is something that is needed.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

It is a single related change.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The component was not getting the old value when submitting a form and getting errors (speaking outside of livewire), what was added was support for that functionality.

5️⃣ Thanks for contributing! 🙌
