### PR TITLE
Support simple array options in x-select

### DIFF
--- a/tests/Components/Inputs/SelectTest.php
+++ b/tests/Components/Inputs/SelectTest.php
@@ -307,3 +307,34 @@ it('can prepend and append options', function () {
         })
         ->assertSeeInOrder(['Germany', 'Canada', 'United States', 'France']);
 });
+
+test('simple array options are supported', function () {
+    $options = [
+        'option_1',
+        'option_2',
+    ];
+
+    $template = <<<'HTML'
+    <form>
+        <x-select name="my_options" :options="$options" />
+    </form>
+    HTML;
+
+    Route::get('/test', fn () => Blade::render($template, ['options' => $options]));
+
+    get('/test')
+        ->assertFormExists('form', function (AssertForm $form) {
+            $form->findSelect('select', function (AssertSelect $select) {
+                $select->containsOptions(
+                    [
+                        'value' => 'option_1',
+                        'text' => 'option_1',
+                    ],
+                    [
+                        'value' => 'option_2',
+                        'text' => 'option_2',
+                    ],
+                );
+            });
+        });
+});


### PR DESCRIPTION
In the `x-select` component, simple array options are not being mapped correctly and causing errors to be thrown. 

```html
<x-select 
    :options="[
        'option_1',
        'option_2',
    ]"
/>
```

This will cause the select to mistake them as "opt groups", and inside the `@foreach` loop on the option, it will throw an error because it will try to iterate over a string instead of an array.

This PR will normalize the options the same way that `x-custom-select` does, and will fix this issue. The `x-select` component will no longer try to render them as opt groups.