### PR TITLE
Content Security Policy Support

### DIFF
--- a/src/FormComponents.php
+++ b/src/FormComponents.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rawilk\FormComponents;
 
+use Illuminate\Support\Facades\Vite;
+
 final class FormComponents
 {
     /**
@@ -22,6 +24,7 @@ final class FormComponents
     private function javaScriptAssets(array $options = []): string
     {
         $assetsUrl = config('form-components.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+        $nonce = $this->getNonce($options);
 
         $manifest = json_decode(file_get_contents(__DIR__ . '/../dist/manifest.json'), true);
         $versionedFileName = $manifest['/form-components.js'];
@@ -29,7 +32,30 @@ final class FormComponents
         $fullAssetPath = "{$assetsUrl}/form-components{$versionedFileName}";
 
         return <<<HTML
-        <script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false"></script>
+        <script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}></script>
         HTML;
+    }
+
+    private function getNonce(array $options): string
+    {
+        if (isset($options['nonce'])) {
+            return "nonce=\"{$options['nonce']}\"";
+        }
+
+        // If there is a csp package installed, i.e. spatie/laravel-csp, we'll check for the existence of the helper function.
+        if (function_exists('csp_nonce') && $nonce = csp_nonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        if (function_exists('cspNonce') && $nonce = cspNonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        // Lastly, we'll check for the existence of a csp nonce from Vite.
+        if (class_exists(Vite::class) && $nonce = Vite::cspNonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        return '';
     }
 }

--- a/tests/Unit/AssetsDirectiveTest.php
+++ b/tests/Unit/AssetsDirectiveTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Str;
 use Rawilk\FormComponents\Facades\FormComponents;
 
 it('outputs the script source', function () {
@@ -42,5 +43,14 @@ it('accepts an asset url as an argument', function () {
     $this->assertStringContainsString(
         '<script src="https://example.com/form-components/form-components.js?',
         FormComponents::javaScript(['asset_url' => 'https://example.com']),
+    );
+});
+
+it('can output a nonce on the script tag', function () {
+    $nonce = Str::random(32);
+
+    $this->assertStringContainsString(
+        "nonce=\"{$nonce}\"",
+        FormComponents::javaScript(['nonce' => $nonce]),
     );
 });


### PR DESCRIPTION
When implementing a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), a common way to allow script files is to use a nonce. This will allow you to specify a nonce to be rendered onto the package scripts by one of the following ways:

- Send it through as an option via the `@fcScripts` blade directive (The `<fc:scripts />` custom tag does not support this)
```html
@fcScripts(['nonce' => 'my-nonce'])
```
- Pull in a csp package (such as https://github.com/spatie/laravel-csp)
- Enable `cspNonce` through Vite in a service provider:
```php
Vite::useCspNonce();
```
