### PR TITLE
Update FormComponentsServiceProvider.php

### DIFF
--- a/src/FormComponentsServiceProvider.php
+++ b/src/FormComponentsServiceProvider.php
@@ -81,7 +81,7 @@ class FormComponentsServiceProvider extends PackageServiceProvider
         }
     }
 
-    private function bootRoutes(): void
+    protected function bootRoutes(): void
     {
         Route::get('/form-components/form-components.js', [FormComponentsJavaScriptAssets::class, 'source']);
         Route::get('/form-components/form-components.js.map', [FormComponentsJavaScriptAssets::class, 'maps']);


### PR DESCRIPTION
solved error Access level to Rawilk\FormComponents\FormComponentsServiceProvider::bootRo  
  utes() must be protected (as in class Spatie\LaravelPackageTools\PackageSer  
  viceProvider) or weaker   

after updating Spatie\LaravelPackageTools package to 1.18.1

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

5️⃣ Thanks for contributing! 🙌
